### PR TITLE
EM-3184 Fix WiFi enable not working.

### DIFF
--- a/src/connman.service.in
+++ b/src/connman.service.in
@@ -11,6 +11,8 @@ Wants=network.target remote-fs-pre.target
 Type=dbus
 BusName=net.connman
 Restart=on-failure
+# The prestart modprobe for rfkill was added to fix a race condition where rfkill was not loaded yet.
+ExecStartPre=/sbin/modprobe rfkill_gpio
 ExecStart=@sbindir@/connmand -n -o
 StandardOutput=null
 CapabilityBoundingSet=CAP_KILL CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_SYS_TIME CAP_SYS_MODULE


### PR DESCRIPTION
On system startup there is an error message from connman "Failed to open RFKILL control device". This turns out to be caused by the RFKILL menu to be loaded when connman starts, that's too late. We added a modprobe command as a prestart command to ensure this dependency is fixed.
Another solution would have been to include the RFKILL module into the Linux kernel, but then the dependency is implicit and not documented.

EM-3184