### PR TITLE
Revert "EM-3619 Disable the online check"

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -98,7 +98,7 @@ static struct {
 	.persistent_tethering_mode = false,
 	.enable_6to4 = false,
 	.vendor_class_id = NULL,
-	.enable_online_check = false,
+	.enable_online_check = true,
 	.auto_connect_roaming_services = false,
 };
 


### PR DESCRIPTION
This reverts commit 28176473245a70caee148533db58c1b39aa144b2.
Enable the online check again. It's used by the firmware update check amongst others.