### PR TITLE
CES-3145 Patch bullseye connman with ultimaker functions

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -2,7 +2,7 @@ Package: @PACKAGE_NAME@
 Version: @RELEASE_VERSION@
 Architecture: @ARCH@
 Maintainer: Anonymous <software-embedded@ultimaker.com>
-Depends: libc6 (>= 2.15), libdbus-1-3 (>= 1.9.14), libglib2.0-0 (>= 2.31.8), libgnutls30 (>= 3.6.5), libreadline7 (>= 6.0), libxtables12 (>= 1.6.0+snapshot20161117), dbus, lsb-base, iptables
+Depends: libc6 (>= 2.15), libdbus-1-3 (>= 1.9.14), libglib2.0-0 (>= 2.31.8), libgnutls30 (>= 3.6.5), libreadline8 (>= 6.0), libxtables12 (>= 1.6.0+snapshot20161117), dbus, lsb-base, iptables
 Priority: optional
 Description: Intel Connection Manager daemon
  The Linux Connection Manager project provides a daemon for managing

--- a/debian/patches/CVE-2023-28488.patch
+++ b/debian/patches/CVE-2023-28488.patch
@@ -1,0 +1,58 @@
+From 99e2c16ea1cced34a5dc450d76287a1c3e762138 Mon Sep 17 00:00:00 2001
+From: Daniel Wagner <wagi@monom.org>
+Date: Tue, 11 Apr 2023 08:12:56 +0200
+Subject: gdhcp: Verify and sanitize packet length first
+
+Avoid overwriting the read packet length after the initial test. Thus
+move all the length checks which depends on the total length first
+and do not use the total lenght from the IP packet afterwards.
+
+Fixes CVE-2023-28488
+
+Reported by Polina Smirnova <moe.hwr@gmail.com>
+---
+ gdhcp/client.c | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/gdhcp/client.c b/gdhcp/client.c
+index 7efa7e45..82017692 100644
+--- a/gdhcp/client.c
++++ b/gdhcp/client.c
+@@ -1319,9 +1319,9 @@ static bool sanity_check(struct ip_udp_dhcp_packet *packet, int bytes)
+ static int dhcp_recv_l2_packet(struct dhcp_packet *dhcp_pkt, int fd,
+ 				struct sockaddr_in *dst_addr)
+ {
+-	int bytes;
+ 	struct ip_udp_dhcp_packet packet;
+ 	uint16_t check;
++	int bytes, tot_len;
+ 
+ 	memset(&packet, 0, sizeof(packet));
+ 
+@@ -1329,15 +1329,17 @@ static int dhcp_recv_l2_packet(struct dhcp_packet *dhcp_pkt, int fd,
+ 	if (bytes < 0)
+ 		return -1;
+ 
+-	if (bytes < (int) (sizeof(packet.ip) + sizeof(packet.udp)))
+-		return -1;
+-
+-	if (bytes < ntohs(packet.ip.tot_len))
++	tot_len = ntohs(packet.ip.tot_len);
++	if (bytes > tot_len) {
++		/* ignore any extra garbage bytes */
++		bytes = tot_len;
++	} else if (bytes < tot_len) {
+ 		/* packet is bigger than sizeof(packet), we did partial read */
+ 		return -1;
++	}
+ 
+-	/* ignore any extra garbage bytes */
+-	bytes = ntohs(packet.ip.tot_len);
++	if (bytes < (int) (sizeof(packet.ip) + sizeof(packet.udp)))
++		return -1;
+ 
+ 	if (!sanity_check(&packet, bytes))
+ 		return -1;
+-- 
+cgit 
+

--- a/debian/patches/dnsproxy-Add-length-checks-to-prevent-buffer-overflo.patch
+++ b/debian/patches/dnsproxy-Add-length-checks-to-prevent-buffer-overflo.patch
@@ -1,0 +1,55 @@
+From 5877e2c17fc2df69fc8169f50d87ce16a24965f1 Mon Sep 17 00:00:00 2001
+From: Colin Wee <cwee@tesla.com>
+Date: Thu, 28 Jan 2021 19:41:53 +0100
+Subject: [PATCH 3/3] dnsproxy: Add length checks to prevent buffer overflow
+
+CVE-2021-26675
+---
+ src/dnsproxy.c | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/src/dnsproxy.c b/src/dnsproxy.c
+index a7bf87a14435..4f5c897f75d9 100644
+--- a/src/dnsproxy.c
++++ b/src/dnsproxy.c
+@@ -1767,6 +1767,7 @@ static char *uncompress(int16_t field_count, char *start, char *end,
+ 			char **uncompressed_ptr)
+ {
+ 	char *uptr = *uncompressed_ptr; /* position in result buffer */
++	char * const uncomp_end = uncompressed + uncomp_len - 1;
+ 
+ 	debug("count %d ptr %p end %p uptr %p", field_count, ptr, end, uptr);
+ 
+@@ -1787,12 +1788,15 @@ static char *uncompress(int16_t field_count, char *start, char *end,
+ 		 * tmp buffer.
+ 		 */
+ 
+-		ulen = strlen(name);
+-		strncpy(uptr, name, uncomp_len - (uptr - uncompressed));
+-
+ 		debug("pos %d ulen %d left %d name %s", pos, ulen,
+ 			(int)(uncomp_len - (uptr - uncompressed)), uptr);
+ 
++		ulen = strlen(name);
++		if ((uptr + ulen + 1) > uncomp_end) {
++			goto out;
++		}
++		strncpy(uptr, name, uncomp_len - (uptr - uncompressed));
++
+ 		uptr += ulen;
+ 		*uptr++ = '\0';
+ 
+@@ -1802,6 +1806,10 @@ static char *uncompress(int16_t field_count, char *start, char *end,
+ 		 * We copy also the fixed portion of the result (type, class,
+ 		 * ttl, address length and the address)
+ 		 */
++		if ((uptr + NS_RRFIXEDSZ) > uncomp_end) {
++			debug("uncompressed data too large for buffer");
++			goto out;
++		}
+ 		memcpy(uptr, ptr, NS_RRFIXEDSZ);
+ 
+ 		dns_type = uptr[0] << 8 | uptr[1];
+-- 
+2.30.0
+

--- a/debian/patches/dnsproxy-Avoid-100-busy-loop-in-TCP-server-case.patch
+++ b/debian/patches/dnsproxy-Avoid-100-busy-loop-in-TCP-server-case.patch
@@ -1,0 +1,45 @@
+From: Matthias Gerstner <mgerstner@suse.de>
+Date: Tue, 25 Jan 2022 10:00:25 +0100
+Subject: dnsproxy: Avoid 100 % busy loop in TCP server case
+Origin: https://git.kernel.org/pub/scm/network/connman/connman.git/commit?id=d8708b85c1e8fe25af7803e8a20cf20e7201d8a4
+Bug-Debian: https://bugs.debian.org/1004935
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2022-23098
+
+Once the TCP socket is connected and until the remote server is
+responding (if ever) ConnMan executes a 100 % CPU loop, since
+the connected socket will always be writable (G_IO_OUT).
+
+To fix this, modify the watch after the connection is established to
+remove the G_IO_OUT from the callback conditions.
+
+Fixes: CVE-2022-23098
+---
+ src/dnsproxy.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/src/dnsproxy.c b/src/dnsproxy.c
+index c027bcb972c4..1ccf36a95a35 100644
+--- a/src/dnsproxy.c
++++ b/src/dnsproxy.c
+@@ -2360,6 +2360,18 @@ hangup:
+ 			}
+ 		}
+ 
++		/*
++		 * Remove the G_IO_OUT flag from the watch, otherwise we end
++		 * up in a busy loop, because the socket is constantly writable.
++		 *
++		 * There seems to be no better way in g_io to do that than
++		 * re-adding the watch.
++		 */
++		g_source_remove(server->watch);
++		server->watch = g_io_add_watch(server->channel,
++			G_IO_IN | G_IO_HUP | G_IO_NVAL | G_IO_ERR,
++			tcp_server_event, server);
++
+ 		server->connected = true;
+ 		server_list = g_slist_append(server_list, server);
+ 
+-- 
+2.37.2
+

--- a/debian/patches/dnsproxy-Check-the-length-of-buffers-before-memcpy.patch
+++ b/debian/patches/dnsproxy-Check-the-length-of-buffers-before-memcpy.patch
@@ -1,0 +1,68 @@
+From: Valery Kashcheev <v.kascheev@omp.ru>
+Date: Mon, 7 Jun 2021 18:58:24 +0200
+Subject: dnsproxy: Check the length of buffers before memcpy
+Origin: https://git.kernel.org/pub/scm/network/connman/connman.git/commit?id=eceb2e8d2341c041df55a5e2f047d9a8c491463c
+Bug-Debian: https://bugs.debian.org/989662
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2021-33833
+
+Fix using a stack-based buffer overflow attack by checking the length of
+the ptr and uptr buffers.
+
+Fix debug message output.
+
+Fixes: CVE-2021-33833
+---
+ src/dnsproxy.c | 20 +++++++++++---------
+ 1 file changed, 11 insertions(+), 9 deletions(-)
+
+diff --git a/src/dnsproxy.c b/src/dnsproxy.c
+index de52df5ad0a0..38dbdd71e425 100644
+--- a/src/dnsproxy.c
++++ b/src/dnsproxy.c
+@@ -1788,17 +1788,15 @@ static char *uncompress(int16_t field_count, char *start, char *end,
+ 		 * tmp buffer.
+ 		 */
+ 
+-		debug("pos %d ulen %d left %d name %s", pos, ulen,
+-			(int)(uncomp_len - (uptr - uncompressed)), uptr);
+-
+-		ulen = strlen(name);
+-		if ((uptr + ulen + 1) > uncomp_end) {
++		ulen = strlen(name) + 1;
++		if ((uptr + ulen) > uncomp_end)
+ 			goto out;
+-		}
+-		strncpy(uptr, name, uncomp_len - (uptr - uncompressed));
++		strncpy(uptr, name, ulen);
++
++		debug("pos %d ulen %d left %d name %s", pos, ulen,
++			(int)(uncomp_end - (uptr + ulen)), uptr);
+ 
+ 		uptr += ulen;
+-		*uptr++ = '\0';
+ 
+ 		ptr += pos;
+ 
+@@ -1841,7 +1839,7 @@ static char *uncompress(int16_t field_count, char *start, char *end,
+ 		} else if (dns_type == ns_t_a || dns_type == ns_t_aaaa) {
+ 			dlen = uptr[-2] << 8 | uptr[-1];
+ 
+-			if (ptr + dlen > end) {
++			if ((ptr + dlen) > end || (uptr + dlen) > uncomp_end) {
+ 				debug("data len %d too long", dlen);
+ 				goto out;
+ 			}
+@@ -1880,6 +1878,10 @@ static char *uncompress(int16_t field_count, char *start, char *end,
+ 			 * refresh interval, retry interval, expiration
+ 			 * limit and minimum ttl). They are 20 bytes long.
+ 			 */
++			if ((uptr + 20) > uncomp_end || (ptr + 20) > end) {
++				debug("soa record too long");
++				goto out;
++			}
+ 			memcpy(uptr, ptr, 20);
+ 			uptr += 20;
+ 			ptr += 20;
+-- 
+2.32.0
+

--- a/debian/patches/dnsproxy-Keep-timeout-in-TCP-case-even-after-connect.patch
+++ b/debian/patches/dnsproxy-Keep-timeout-in-TCP-case-even-after-connect.patch
@@ -1,0 +1,37 @@
+From: Matthias Gerstner <mgerstner@suse.de>
+Date: Tue, 25 Jan 2022 10:00:26 +0100
+Subject: dnsproxy: Keep timeout in TCP case even after connection is
+ established
+Origin: https://git.kernel.org/pub/scm/network/connman/connman.git/commit?id=5c34313a196515c80fe78a2862ad78174b985be5
+Bug-Debian: https://bugs.debian.org/1004935
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2022-23098
+
+If an outgoing TCP connection succeeds but the remote server never sends
+back any data then currently the TCP connection will never be
+terminated by connmand.
+
+To prevent this keep the connection timeout of 30 seconds active even
+after the connection has been established.
+---
+ src/dnsproxy.c | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/src/dnsproxy.c b/src/dnsproxy.c
+index 1ccf36a95a35..cf1d36c74496 100644
+--- a/src/dnsproxy.c
++++ b/src/dnsproxy.c
+@@ -2375,11 +2375,6 @@ hangup:
+ 		server->connected = true;
+ 		server_list = g_slist_append(server_list, server);
+ 
+-		if (server->timeout > 0) {
+-			g_source_remove(server->timeout);
+-			server->timeout = 0;
+-		}
+-
+ 		for (list = request_list; list; ) {
+ 			struct request_data *req = list->data;
+ 			int status;
+-- 
+2.37.2
+

--- a/debian/patches/dnsproxy-Simplify-udp_server_event.patch
+++ b/debian/patches/dnsproxy-Simplify-udp_server_event.patch
@@ -1,0 +1,40 @@
+From: Slava Monich <slava.monich@jolla.com>
+Date: Thu, 23 Aug 2018 18:24:41 +0300
+Subject: dnsproxy: Simplify udp_server_event()
+Origin: https://git.kernel.org/pub/scm/network/connman/connman.git/commit?id=de020cc7e8ad11f81c879f60f22348f8a7798d4c
+
+---
+ src/dnsproxy.c | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/src/dnsproxy.c b/src/dnsproxy.c
+index 1db3eae9cb47..49bc395c733a 100644
+--- a/src/dnsproxy.c
++++ b/src/dnsproxy.c
+@@ -2231,7 +2231,7 @@ static gboolean udp_server_event(GIOChannel *channel, GIOCondition condition,
+ 							gpointer user_data)
+ {
+ 	unsigned char buf[4096];
+-	int sk, err, len;
++	int sk, len;
+ 	struct server_data *data = user_data;
+ 
+ 	if (condition & (G_IO_NVAL | G_IO_ERR | G_IO_HUP)) {
+@@ -2243,12 +2243,9 @@ static gboolean udp_server_event(GIOChannel *channel, GIOCondition condition,
+ 	sk = g_io_channel_unix_get_fd(channel);
+ 
+ 	len = recv(sk, buf, sizeof(buf), 0);
+-	if (len < 12)
+-		return TRUE;
+ 
+-	err = forward_dns_reply(buf, len, IPPROTO_UDP, data);
+-	if (err < 0)
+-		return TRUE;
++	if (len >= 12)
++		forward_dns_reply(buf, len, IPPROTO_UDP, data);
+ 
+ 	return TRUE;
+ }
+-- 
+2.37.2
+

--- a/debian/patches/dnsproxy-Validate-input-data-before-using-them.patch
+++ b/debian/patches/dnsproxy-Validate-input-data-before-using-them.patch
@@ -1,0 +1,117 @@
+From: Daniel Wagner <wagi@monom.org>
+Date: Tue, 25 Jan 2022 10:00:24 +0100
+Subject: dnsproxy: Validate input data before using them
+Origin: https://git.kernel.org/pub/scm/network/connman/connman.git/commit?id=e5a313736e13c90d19085e953a26256a198e4950
+Bug-Debian: https://bugs.debian.org/1004935
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2022-23097
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2022-23096
+
+dnsproxy is not validating various input data. Add a bunch of checks.
+
+Fixes: CVE-2022-23097
+Fixes: CVE-2022-23096
+---
+ src/dnsproxy.c | 31 ++++++++++++++++++++++++++-----
+ 1 file changed, 26 insertions(+), 5 deletions(-)
+
+diff --git a/src/dnsproxy.c b/src/dnsproxy.c
+index cdfafbc292f2..c027bcb972c4 100644
+--- a/src/dnsproxy.c
++++ b/src/dnsproxy.c
+@@ -1951,6 +1951,12 @@ static int forward_dns_reply(unsigned char *reply, int reply_len, int protocol,
+ 
+ 	if (offset < 0)
+ 		return offset;
++	if (reply_len < 0)
++		return -EINVAL;
++	if (reply_len < offset + 1)
++		return -EINVAL;
++	if ((size_t)reply_len < sizeof(struct domain_hdr))
++		return -EINVAL;
+ 
+ 	hdr = (void *)(reply + offset);
+ 	dns_id = reply[offset] | reply[offset + 1] << 8;
+@@ -1986,23 +1992,31 @@ static int forward_dns_reply(unsigned char *reply, int reply_len, int protocol,
+ 		 */
+ 		if (req->append_domain && ntohs(hdr->qdcount) == 1) {
+ 			uint16_t domain_len = 0;
+-			uint16_t header_len;
++			uint16_t header_len, payload_len;
+ 			uint16_t dns_type, dns_class;
+ 			uint8_t host_len, dns_type_pos;
+ 			char uncompressed[NS_MAXDNAME], *uptr;
+ 			char *ptr, *eom = (char *)reply + reply_len;
++			char *domain;
+ 
+ 			/*
+ 			 * ptr points to the first char of the hostname.
+ 			 * ->hostname.domain.net
+ 			 */
+ 			header_len = offset + sizeof(struct domain_hdr);
++			if (reply_len < header_len)
++				return -EINVAL;
++			payload_len = reply_len - header_len;
++
+ 			ptr = (char *)reply + header_len;
+ 
+ 			host_len = *ptr;
++			domain = ptr + 1 + host_len;
++			if (domain > eom)
++				return -EINVAL;
++
+ 			if (host_len > 0)
+-				domain_len = strnlen(ptr + 1 + host_len,
+-						reply_len - header_len);
++				domain_len = strnlen(domain, eom - domain);
+ 
+ 			/*
+ 			 * If the query type is anything other than A or AAAA,
+@@ -2011,6 +2025,8 @@ static int forward_dns_reply(unsigned char *reply, int reply_len, int protocol,
+ 			 */
+ 			dns_type_pos = host_len + 1 + domain_len + 1;
+ 
++			if (ptr + (dns_type_pos + 3) > eom)
++				return -EINVAL;
+ 			dns_type = ptr[dns_type_pos] << 8 |
+ 							ptr[dns_type_pos + 1];
+ 			dns_class = ptr[dns_type_pos + 2] << 8 |
+@@ -2040,6 +2056,8 @@ static int forward_dns_reply(unsigned char *reply, int reply_len, int protocol,
+ 				int new_len, fixed_len;
+ 				char *answers;
+ 
++				if (len > payload_len)
++					return -EINVAL;
+ 				/*
+ 				 * First copy host (without domain name) into
+ 				 * tmp buffer.
+@@ -2054,6 +2072,8 @@ static int forward_dns_reply(unsigned char *reply, int reply_len, int protocol,
+ 				 * Copy type and class fields of the question.
+ 				 */
+ 				ptr += len + domain_len + 1;
++				if (ptr + NS_QFIXEDSZ > eom)
++					return -EINVAL;
+ 				memcpy(uptr, ptr, NS_QFIXEDSZ);
+ 
+ 				/*
+@@ -2063,6 +2083,8 @@ static int forward_dns_reply(unsigned char *reply, int reply_len, int protocol,
+ 				uptr += NS_QFIXEDSZ;
+ 				answers = uptr;
+ 				fixed_len = answers - uncompressed;
++				if (ptr + offset > eom)
++					return -EINVAL;
+ 
+ 				/*
+ 				 * We then uncompress the result to buffer
+@@ -2257,8 +2279,7 @@ static gboolean udp_server_event(GIOChannel *channel, GIOCondition condition,
+ 
+ 	len = recv(sk, buf, sizeof(buf), 0);
+ 
+-	if (len >= 12)
+-		forward_dns_reply(buf, len, IPPROTO_UDP, data);
++	forward_dns_reply(buf, len, IPPROTO_UDP, data);
+ 
+ 	return TRUE;
+ }
+-- 
+2.37.2
+

--- a/debian/patches/gdhcp-Avoid-leaking-stack-data-via-unitiialized-vari.patch
+++ b/debian/patches/gdhcp-Avoid-leaking-stack-data-via-unitiialized-vari.patch
@@ -1,0 +1,26 @@
+From 013dc6e2a218067f5b5ff9cce10a0a143abb2a59 Mon Sep 17 00:00:00 2001
+From: Colin Wee <cwee@tesla.com>
+Date: Thu, 28 Jan 2021 19:41:09 +0100
+Subject: [PATCH 2/3] gdhcp: Avoid leaking stack data via unitiialized variable
+
+CVE-2021-26676
+---
+ gdhcp/client.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdhcp/client.c b/gdhcp/client.c
+index 6a5613e7d5aa..c7b85e58e2be 100644
+--- a/gdhcp/client.c
++++ b/gdhcp/client.c
+@@ -2270,7 +2270,7 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
+ {
+ 	GDHCPClient *dhcp_client = user_data;
+ 	struct sockaddr_in dst_addr = { 0 };
+-	struct dhcp_packet packet;
++	struct dhcp_packet packet = { 0 };
+ 	struct dhcpv6_packet *packet6 = NULL;
+ 	uint8_t *message_type = NULL, *client_id = NULL, *option,
+ 		*server_id = NULL;
+-- 
+2.30.0
+

--- a/debian/patches/gdhcp-Avoid-reading-invalid-data-in-dhcp_get_option.patch
+++ b/debian/patches/gdhcp-Avoid-reading-invalid-data-in-dhcp_get_option.patch
@@ -1,0 +1,226 @@
+From 2232e3bc3ea7794720263e8fc8f1797d877c6222 Mon Sep 17 00:00:00 2001
+From: Colin Wee <cwee@tesla.com>
+Date: Thu, 28 Jan 2021 19:39:14 +0100
+Subject: [PATCH 1/3] gdhcp: Avoid reading invalid data in dhcp_get_option
+
+CVE-2021-26676
+---
+ gdhcp/client.c | 20 +++++++++++---------
+ gdhcp/common.c | 24 +++++++++++++++++++-----
+ gdhcp/common.h |  2 +-
+ gdhcp/server.c | 12 +++++++-----
+ 4 files changed, 38 insertions(+), 20 deletions(-)
+
+diff --git a/gdhcp/client.c b/gdhcp/client.c
+index 09dfe5ec2991..6a5613e7d5aa 100644
+--- a/gdhcp/client.c
++++ b/gdhcp/client.c
+@@ -1629,12 +1629,12 @@ static void start_request(GDHCPClient *dhcp_client)
+ 							NULL);
+ }
+ 
+-static uint32_t get_lease(struct dhcp_packet *packet)
++static uint32_t get_lease(struct dhcp_packet *packet, uint16_t packet_len)
+ {
+ 	uint8_t *option;
+ 	uint32_t lease_seconds;
+ 
+-	option = dhcp_get_option(packet, DHCP_LEASE_TIME);
++	option = dhcp_get_option(packet, packet_len, DHCP_LEASE_TIME);
+ 	if (!option)
+ 		return 3600;
+ 
+@@ -2226,7 +2226,8 @@ static void get_dhcpv6_request(GDHCPClient *dhcp_client,
+ 	}
+ }
+ 
+-static void get_request(GDHCPClient *dhcp_client, struct dhcp_packet *packet)
++static void get_request(GDHCPClient *dhcp_client, struct dhcp_packet *packet,
++		uint16_t packet_len)
+ {
+ 	GDHCPOptionType type;
+ 	GList *list, *value_list;
+@@ -2237,7 +2238,7 @@ static void get_request(GDHCPClient *dhcp_client, struct dhcp_packet *packet)
+ 	for (list = dhcp_client->request_list; list; list = list->next) {
+ 		code = (uint8_t) GPOINTER_TO_INT(list->data);
+ 
+-		option = dhcp_get_option(packet, code);
++		option = dhcp_get_option(packet, packet_len, code);
+ 		if (!option) {
+ 			g_hash_table_remove(dhcp_client->code_value_hash,
+ 						GINT_TO_POINTER((int) code));
+@@ -2297,6 +2298,7 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
+ 		re = dhcp_recv_l2_packet(&packet,
+ 					dhcp_client->listener_sockfd,
+ 					&dst_addr);
++		pkt_len = (uint16_t)(unsigned int)re;
+ 		xid = packet.xid;
+ 	} else if (dhcp_client->listen_mode == L3) {
+ 		if (dhcp_client->type == G_DHCP_IPV6) {
+@@ -2361,7 +2363,7 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
+ 			dhcp_client->status_code = status;
+ 		}
+ 	} else {
+-		message_type = dhcp_get_option(&packet, DHCP_MESSAGE_TYPE);
++		message_type = dhcp_get_option(&packet, pkt_len, DHCP_MESSAGE_TYPE);
+ 		if (!message_type)
+ 			return TRUE;
+ 	}
+@@ -2378,7 +2380,7 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
+ 		dhcp_client->timeout = 0;
+ 		dhcp_client->retry_times = 0;
+ 
+-		option = dhcp_get_option(&packet, DHCP_SERVER_ID);
++		option = dhcp_get_option(&packet, pkt_len, DHCP_SERVER_ID);
+ 		dhcp_client->server_ip = get_be32(option);
+ 		dhcp_client->requested_ip = ntohl(packet.yiaddr);
+ 
+@@ -2428,9 +2430,9 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
+ 
+ 			remove_timeouts(dhcp_client);
+ 
+-			dhcp_client->lease_seconds = get_lease(&packet);
++			dhcp_client->lease_seconds = get_lease(&packet, pkt_len);
+ 
+-			get_request(dhcp_client, &packet);
++			get_request(dhcp_client, &packet, pkt_len);
+ 
+ 			switch_listening_mode(dhcp_client, L_NONE);
+ 
+@@ -2438,7 +2440,7 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
+ 			dhcp_client->assigned_ip = get_ip(packet.yiaddr);
+ 
+ 			if (dhcp_client->state == REBOOTING) {
+-				option = dhcp_get_option(&packet,
++				option = dhcp_get_option(&packet, pkt_len,
+ 							DHCP_SERVER_ID);
+ 				dhcp_client->server_ip = get_be32(option);
+ 			}
+diff --git a/gdhcp/common.c b/gdhcp/common.c
+index 1d667d17308f..c8916aa81666 100644
+--- a/gdhcp/common.c
++++ b/gdhcp/common.c
+@@ -73,18 +73,21 @@ GDHCPOptionType dhcp_get_code_type(uint8_t code)
+ 	return OPTION_UNKNOWN;
+ }
+ 
+-uint8_t *dhcp_get_option(struct dhcp_packet *packet, int code)
++uint8_t *dhcp_get_option(struct dhcp_packet *packet, uint16_t packet_len, int code)
+ {
+ 	int len, rem;
+-	uint8_t *optionptr;
++	uint8_t *optionptr, *options_end;
++	size_t options_len;
+ 	uint8_t overload = 0;
+ 
+ 	/* option bytes: [code][len][data1][data2]..[dataLEN] */
+ 	optionptr = packet->options;
+ 	rem = sizeof(packet->options);
++	options_len = packet_len - (sizeof(*packet) - sizeof(packet->options));
++	options_end = optionptr + options_len - 1;
+ 
+ 	while (1) {
+-		if (rem <= 0)
++		if ((rem <= 0) && (optionptr + OPT_CODE > options_end))
+ 			/* Bad packet, malformed option field */
+ 			return NULL;
+ 
+@@ -115,14 +118,25 @@ uint8_t *dhcp_get_option(struct dhcp_packet *packet, int code)
+ 			break;
+ 		}
+ 
++		if (optionptr + OPT_LEN > options_end) {
++			/* bad packet, would read length field from OOB */
++			return NULL;
++		}
++
+ 		len = 2 + optionptr[OPT_LEN];
+ 
+ 		rem -= len;
+ 		if (rem < 0)
+ 			continue; /* complain and return NULL */
+ 
+-		if (optionptr[OPT_CODE] == code)
+-			return optionptr + OPT_DATA;
++		if (optionptr[OPT_CODE] == code) {
++			if (optionptr + len > options_end) {
++				/* bad packet, option length points OOB */
++				return NULL;
++			} else {
++				return optionptr + OPT_DATA;
++			}
++		}
+ 
+ 		if (optionptr[OPT_CODE] == DHCP_OPTION_OVERLOAD)
+ 			overload |= optionptr[OPT_DATA];
+diff --git a/gdhcp/common.h b/gdhcp/common.h
+index 9660231cc49d..8f63fd755623 100644
+--- a/gdhcp/common.h
++++ b/gdhcp/common.h
+@@ -179,7 +179,7 @@ struct in6_pktinfo {
+ };
+ #endif
+ 
+-uint8_t *dhcp_get_option(struct dhcp_packet *packet, int code);
++uint8_t *dhcp_get_option(struct dhcp_packet *packet, uint16_t packet_len, int code);
+ uint8_t *dhcpv6_get_option(struct dhcpv6_packet *packet, uint16_t pkt_len,
+ 			int code, uint16_t *option_len, int *option_count);
+ uint8_t *dhcpv6_get_sub_option(unsigned char *option, uint16_t max_len,
+diff --git a/gdhcp/server.c b/gdhcp/server.c
+index 85405f193fe3..52ea2a55b230 100644
+--- a/gdhcp/server.c
++++ b/gdhcp/server.c
+@@ -413,7 +413,7 @@ GDHCPServer *g_dhcp_server_new(GDHCPType type,
+ }
+ 
+ 
+-static uint8_t check_packet_type(struct dhcp_packet *packet)
++static uint8_t check_packet_type(struct dhcp_packet *packet, uint16_t packet_len)
+ {
+ 	uint8_t *type;
+ 
+@@ -423,7 +423,7 @@ static uint8_t check_packet_type(struct dhcp_packet *packet)
+ 	if (packet->op != BOOTREQUEST)
+ 		return 0;
+ 
+-	type = dhcp_get_option(packet, DHCP_MESSAGE_TYPE);
++	type = dhcp_get_option(packet, packet_len, DHCP_MESSAGE_TYPE);
+ 
+ 	if (!type)
+ 		return 0;
+@@ -651,6 +651,7 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
+ 	struct dhcp_lease *lease;
+ 	uint32_t requested_nip = 0;
+ 	uint8_t type, *server_id_option, *request_ip_option;
++	uint16_t packet_len;
+ 	int re;
+ 
+ 	if (condition & (G_IO_NVAL | G_IO_ERR | G_IO_HUP)) {
+@@ -661,12 +662,13 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
+ 	re = dhcp_recv_l3_packet(&packet, dhcp_server->listener_sockfd);
+ 	if (re < 0)
+ 		return TRUE;
++	packet_len = (uint16_t)(unsigned int)re;
+ 
+-	type = check_packet_type(&packet);
++	type = check_packet_type(&packet, packet_len);
+ 	if (type == 0)
+ 		return TRUE;
+ 
+-	server_id_option = dhcp_get_option(&packet, DHCP_SERVER_ID);
++	server_id_option = dhcp_get_option(&packet, packet_len, DHCP_SERVER_ID);
+ 	if (server_id_option) {
+ 		uint32_t server_nid =
+ 			get_unaligned((const uint32_t *) server_id_option);
+@@ -675,7 +677,7 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
+ 			return TRUE;
+ 	}
+ 
+-	request_ip_option = dhcp_get_option(&packet, DHCP_REQUESTED_IP);
++	request_ip_option = dhcp_get_option(&packet, packet_len, DHCP_REQUESTED_IP);
+ 	if (request_ip_option)
+ 		requested_nip = get_be32(request_ip_option);
+ 
+-- 
+2.30.0
+

--- a/debian/patches/gweb-Fix-OOB-write-in-received_data.patch
+++ b/debian/patches/gweb-Fix-OOB-write-in-received_data.patch
@@ -1,0 +1,34 @@
+From: Nathan Crandall <ncrandall@tesla.com>
+Date: Tue, 12 Jul 2022 08:56:34 +0200
+Subject: gweb: Fix OOB write in received_data()
+Origin: https://git.kernel.org/pub/scm/network/connman/connman.git/commit?id=d1a5ede5d255bde8ef707f8441b997563b9312bd
+Bug-Debian: https://bugs.debian.org/1016976
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2022-32292
+
+There is a mismatch of handling binary vs. C-string data with memchr
+and strlen, resulting in pos, count, and bytes_read to become out of
+sync and result in a heap overflow.  Instead, do not treat the buffer
+as an ASCII C-string. We calculate the count based on the return value
+of memchr, instead of strlen.
+
+Fixes: CVE-2022-32292
+---
+ gweb/gweb.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gweb/gweb.c b/gweb/gweb.c
+index 12fcb1d8ab32..13c6c5f25102 100644
+--- a/gweb/gweb.c
++++ b/gweb/gweb.c
+@@ -918,7 +918,7 @@ static gboolean received_data(GIOChannel *channel, GIOCondition cond,
+ 		}
+ 
+ 		*pos = '\0';
+-		count = strlen((char *) ptr);
++		count = pos - ptr;
+ 		if (count > 0 && ptr[count - 1] == '\r') {
+ 			ptr[--count] = '\0';
+ 			bytes_read--;
+-- 
+2.37.2
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,15 @@
 01-init-script-lsb-headers.patch
 manpage-fixes.patch
 iwd-remove-device-state-property.patch
+gdhcp-Avoid-reading-invalid-data-in-dhcp_get_option.patch
+gdhcp-Avoid-leaking-stack-data-via-unitiialized-vari.patch
+dnsproxy-Add-length-checks-to-prevent-buffer-overflo.patch
+dnsproxy-Check-the-length-of-buffers-before-memcpy.patch
+dnsproxy-Simplify-udp_server_event.patch
+dnsproxy-Validate-input-data-before-using-them.patch
+dnsproxy-Avoid-100-busy-loop-in-TCP-server-case.patch
+dnsproxy-Keep-timeout-in-TCP-case-even-after-connect.patch
+gweb-Fix-OOB-write-in-received_data.patch
+wispr-Add-reference-counter-to-portal-context.patch
+wispr-Update-portal-context-references.patch
+CVE-2023-28488.patch

--- a/debian/patches/wispr-Add-reference-counter-to-portal-context.patch
+++ b/debian/patches/wispr-Add-reference-counter-to-portal-context.patch
@@ -1,0 +1,128 @@
+From: Daniel Wagner <wagi@monom.org>
+Date: Tue, 5 Jul 2022 08:32:12 +0200
+Subject: wispr: Add reference counter to portal context
+Origin: https://git.kernel.org/pub/scm/network/connman/connman.git/commit?id=72343929836de80727a27d6744c869dff045757c
+Bug-Debian: https://bugs.debian.org/1016976
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2022-32293
+
+Track the connman_wispr_portal_context live time via a
+refcounter. This only adds the infrastructure to do proper reference
+counting.
+
+Fixes: CVE-2022-32293
+[Salvatore Bonaccorso: Backport to 1.36: Drop changes around f0bd0e8fe578
+("service: Add online to ready transition feature") upstream in 1.40]
+---
+ src/wispr.c | 52 ++++++++++++++++++++++++++++++++++++++++++----------
+ 1 file changed, 42 insertions(+), 10 deletions(-)
+
+--- a/src/wispr.c
++++ b/src/wispr.c
+@@ -59,6 +59,7 @@ struct wispr_route {
+ };
+ 
+ struct connman_wispr_portal_context {
++	int refcount;
+ 	struct connman_service *service;
+ 	enum connman_ipconfig_type type;
+ 	struct connman_wispr_portal *wispr_portal;
+@@ -96,6 +97,11 @@ static bool wispr_portal_web_result(GWeb
+ 
+ static GHashTable *wispr_portal_list = NULL;
+ 
++#define wispr_portal_context_ref(wp_context) \
++	wispr_portal_context_ref_debug(wp_context, __FILE__, __LINE__, __func__)
++#define wispr_portal_context_unref(wp_context) \
++	wispr_portal_context_unref_debug(wp_context, __FILE__, __LINE__, __func__)
++
+ static void connman_wispr_message_init(struct connman_wispr_message *msg)
+ {
+ 	DBG("");
+@@ -161,9 +167,6 @@ static void free_connman_wispr_portal_co
+ {
+ 	DBG("context %p", wp_context);
+ 
+-	if (!wp_context)
+-		return;
+-
+ 	if (wp_context->wispr_portal) {
+ 		if (wp_context->wispr_portal->ipv4_context == wp_context)
+ 			wp_context->wispr_portal->ipv4_context = NULL;
+@@ -200,9 +203,38 @@ static void free_connman_wispr_portal_co
+ 	g_free(wp_context);
+ }
+ 
++static struct connman_wispr_portal_context *
++wispr_portal_context_ref_debug(struct connman_wispr_portal_context *wp_context,
++			const char *file, int line, const char *caller)
++{
++	DBG("%p ref %d by %s:%d:%s()", wp_context,
++		wp_context->refcount + 1, file, line, caller);
++
++	__sync_fetch_and_add(&wp_context->refcount, 1);
++
++	return wp_context;
++}
++
++static void wispr_portal_context_unref_debug(
++		struct connman_wispr_portal_context *wp_context,
++		const char *file, int line, const char *caller)
++{
++	if (!wp_context)
++		return;
++
++	DBG("%p ref %d by %s:%d:%s()", wp_context,
++		wp_context->refcount - 1, file, line, caller);
++
++	if (__sync_fetch_and_sub(&wp_context->refcount, 1) != 1)
++		return;
++
++	free_connman_wispr_portal_context(wp_context);
++}
++
+ static struct connman_wispr_portal_context *create_wispr_portal_context(void)
+ {
+-	return g_try_new0(struct connman_wispr_portal_context, 1);
++	return wispr_portal_context_ref(
++		g_new0(struct connman_wispr_portal_context, 1));
+ }
+ 
+ static void free_connman_wispr_portal(gpointer data)
+@@ -214,8 +246,8 @@ static void free_connman_wispr_portal(gp
+ 	if (!wispr_portal)
+ 		return;
+ 
+-	free_connman_wispr_portal_context(wispr_portal->ipv4_context);
+-	free_connman_wispr_portal_context(wispr_portal->ipv6_context);
++	wispr_portal_context_unref(wispr_portal->ipv4_context);
++	wispr_portal_context_unref(wispr_portal->ipv6_context);
+ 
+ 	g_free(wispr_portal);
+ }
+@@ -592,7 +624,7 @@ static void wispr_portal_request_wispr_l
+ 				return;
+ 		}
+ 
+-		free_connman_wispr_portal_context(wp_context);
++		wispr_portal_context_unref(wp_context);
+ 		return;
+ 	}
+ 
+@@ -903,7 +935,7 @@ static int wispr_portal_detect(struct co
+ 
+ 		if (wp_context->token == 0) {
+ 			err = -EINVAL;
+-			free_connman_wispr_portal_context(wp_context);
++			wispr_portal_context_unref(wp_context);
+ 		}
+ 	} else if (wp_context->timeout == 0) {
+ 		wp_context->timeout = g_idle_add(no_proxy_callback, wp_context);
+@@ -952,7 +984,7 @@ int __connman_wispr_start(struct connman
+ 
+ 	/* If there is already an existing context, we wipe it */
+ 	if (wp_context)
+-		free_connman_wispr_portal_context(wp_context);
++		wispr_portal_context_unref(wp_context);
+ 
+ 	wp_context = create_wispr_portal_context();
+ 	if (!wp_context)

--- a/debian/patches/wispr-Update-portal-context-references.patch
+++ b/debian/patches/wispr-Update-portal-context-references.patch
@@ -1,0 +1,160 @@
+From: Daniel Wagner <wagi@monom.org>
+Date: Tue, 5 Jul 2022 09:11:09 +0200
+Subject: wispr: Update portal context references
+Origin: https://git.kernel.org/pub/scm/network/connman/connman.git/commit?id=416bfaff988882c553c672e5bfc2d4f648d29e8a
+Bug-Debian: https://bugs.debian.org/1016976
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2022-32293
+
+Maintain proper portal context references to avoid UAF.
+
+Fixes: CVE-2022-32293
+[Salvatore Bonaccorso: Backport to 1.36: Drop changes around f0bd0e8fe578
+("service: Add online to ready transition feature") upstream in 1.40]
+---
+ src/wispr.c | 34 ++++++++++++++++++++++------------
+ 1 file changed, 22 insertions(+), 12 deletions(-)
+
+--- a/src/wispr.c
++++ b/src/wispr.c
+@@ -104,8 +104,6 @@ static GHashTable *wispr_portal_list = N
+ 
+ static void connman_wispr_message_init(struct connman_wispr_message *msg)
+ {
+-	DBG("");
+-
+ 	msg->has_error = false;
+ 	msg->current_element = NULL;
+ 
+@@ -165,8 +163,6 @@ static void free_wispr_routes(struct con
+ static void free_connman_wispr_portal_context(
+ 		struct connman_wispr_portal_context *wp_context)
+ {
+-	DBG("context %p", wp_context);
+-
+ 	if (wp_context->wispr_portal) {
+ 		if (wp_context->wispr_portal->ipv4_context == wp_context)
+ 			wp_context->wispr_portal->ipv4_context = NULL;
+@@ -541,14 +537,17 @@ static void wispr_portal_request_portal(
+ {
+ 	DBG("");
+ 
++	wispr_portal_context_ref(wp_context);
+ 	wp_context->request_id = g_web_request_get(wp_context->web,
+ 					wp_context->status_url,
+ 					wispr_portal_web_result,
+ 					wispr_route_request,
+ 					wp_context);
+ 
+-	if (wp_context->request_id == 0)
++	if (wp_context->request_id == 0) {
+ 		wispr_portal_error(wp_context);
++		wispr_portal_context_unref(wp_context);
++	}
+ }
+ 
+ static bool wispr_input(const guint8 **data, gsize *length,
+@@ -594,13 +593,15 @@ static void wispr_portal_browser_reply_c
+ 		return;
+ 
+ 	if (!authentication_done) {
+-		wispr_portal_error(wp_context);
+ 		free_wispr_routes(wp_context);
++		wispr_portal_error(wp_context);
++		wispr_portal_context_unref(wp_context);
+ 		return;
+ 	}
+ 
+ 	/* Restarting the test */
+ 	__connman_service_wispr_start(service, wp_context->type);
++	wispr_portal_context_unref(wp_context);
+ }
+ 
+ static void wispr_portal_request_wispr_login(struct connman_service *service,
+@@ -676,11 +677,13 @@ static bool wispr_manage_message(GWebRes
+ 
+ 		wp_context->wispr_result = CONNMAN_WISPR_RESULT_LOGIN;
+ 
++		wispr_portal_context_ref(wp_context);
+ 		if (__connman_agent_request_login_input(wp_context->service,
+ 					wispr_portal_request_wispr_login,
+-					wp_context) != -EINPROGRESS)
++					wp_context) != -EINPROGRESS) {
+ 			wispr_portal_error(wp_context);
+-		else
++			wispr_portal_context_unref(wp_context);
++		} else
+ 			return true;
+ 
+ 		break;
+@@ -729,6 +732,7 @@ static bool wispr_portal_web_result(GWeb
+ 		if (length > 0) {
+ 			g_web_parser_feed_data(wp_context->wispr_parser,
+ 								chunk, length);
++			wispr_portal_context_unref(wp_context);
+ 			return true;
+ 		}
+ 
+@@ -746,6 +750,7 @@ static bool wispr_portal_web_result(GWeb
+ 
+ 	switch (status) {
+ 	case 000:
++		wispr_portal_context_ref(wp_context);
+ 		__connman_agent_request_browser(wp_context->service,
+ 				wispr_portal_browser_reply_cb,
+ 				wp_context->status_url, wp_context);
+@@ -757,11 +762,14 @@ static bool wispr_portal_web_result(GWeb
+ 		if (g_web_result_get_header(result, "X-ConnMan-Status",
+ 						&str)) {
+ 			portal_manage_status(result, wp_context);
++			wispr_portal_context_unref(wp_context);
+ 			return false;
+-		} else
++		} else {
++			wispr_portal_context_ref(wp_context);
+ 			__connman_agent_request_browser(wp_context->service,
+ 					wispr_portal_browser_reply_cb,
+ 					wp_context->redirect_url, wp_context);
++		}
+ 
+ 		break;
+ 	case 302:
+@@ -769,6 +777,7 @@ static bool wispr_portal_web_result(GWeb
+ 			!g_web_result_get_header(result, "Location",
+ 							&redirect)) {
+ 
++			wispr_portal_context_ref(wp_context);
+ 			__connman_agent_request_browser(wp_context->service,
+ 					wispr_portal_browser_reply_cb,
+ 					wp_context->status_url, wp_context);
+@@ -779,6 +788,7 @@ static bool wispr_portal_web_result(GWeb
+ 
+ 		wp_context->redirect_url = g_strdup(redirect);
+ 
++		wispr_portal_context_ref(wp_context);
+ 		wp_context->request_id = g_web_request_get(wp_context->web,
+ 				redirect, wispr_portal_web_result,
+ 				wispr_route_request, wp_context);
+@@ -795,6 +805,7 @@ static bool wispr_portal_web_result(GWeb
+ 
+ 		break;
+ 	case 505:
++		wispr_portal_context_ref(wp_context);
+ 		__connman_agent_request_browser(wp_context->service,
+ 				wispr_portal_browser_reply_cb,
+ 				wp_context->status_url, wp_context);
+@@ -807,6 +818,7 @@ static bool wispr_portal_web_result(GWeb
+ 	wp_context->request_id = 0;
+ done:
+ 	wp_context->wispr_msg.message_type = -1;
++	wispr_portal_context_unref(wp_context);
+ 	return false;
+ }
+ 
+@@ -841,6 +853,7 @@ static void proxy_callback(const char *p
+ 					xml_wispr_parser_callback, wp_context);
+ 
+ 	wispr_portal_request_portal(wp_context);
++	wispr_portal_context_unref(wp_context);
+ }
+ 
+ static gboolean no_proxy_callback(gpointer user_data)

--- a/doc/connman-vpn-provider.config.5.in
+++ b/doc/connman-vpn-provider.config.5.in
@@ -12,7 +12,7 @@ connection_name.config \- ConnMan vpn connection provisioning file
 \fIConnMan\fP's vpn connections are configured with so called
 "\fBprovisioning files\fP" which reside under \fI@vpn_storagedir@/\fP.
 The files can be named anything, as long as they contain only printable
-ascii characers, for example letters, numbers and underscores. The file
+ascii characters, for example letters, numbers and underscores. The file
 must end with \fB.config\fP. Each VPN connection requires a provisioning
 file, but multiple connections can be specified in the same file.
 .SH "FILE FORMAT"

--- a/doc/connman.conf.5.in
+++ b/doc/connman.conf.5.in
@@ -76,7 +76,7 @@ set up and saved to storage beforehand.
 List of technoolgies which are always connected regardless
 of PreferredTechnologies setting (AutoConnect = true). The
 default value is empty and this feature is disabled unless
-explicitely enabled in the config file.
+explicitly enabled in the config file.
 .TP
 .BI PreferredTechnologies= technology\fR[,...]
 List of preferred technologies from the most preferred

--- a/docker_env/Dockerfile
+++ b/docker_env/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 registry.hub.docker.com/library/debian:buster
+FROM arm64v8/debian:buster
 
 LABEL Maintainer="software-embedded@ultimaker.com" \
       Comment="Ultimaker buster build environment"

--- a/docker_env/Dockerfile
+++ b/docker_env/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/debian:buster
+FROM --platform=linux/amd64 registry.hub.docker.com/library/debian:buster
 
 LABEL Maintainer="software-embedded@ultimaker.com" \
       Comment="Ultimaker buster build environment"

--- a/gdhcp/client.c
+++ b/gdhcp/client.c
@@ -1315,9 +1315,9 @@ static bool sanity_check(struct ip_udp_dhcp_packet *packet, int bytes)
 static int dhcp_recv_l2_packet(struct dhcp_packet *dhcp_pkt, int fd,
 				struct sockaddr_in *dst_addr)
 {
-	int bytes;
 	struct ip_udp_dhcp_packet packet;
 	uint16_t check;
+	int bytes, tot_len;
 
 	memset(&packet, 0, sizeof(packet));
 
@@ -1325,15 +1325,17 @@ static int dhcp_recv_l2_packet(struct dhcp_packet *dhcp_pkt, int fd,
 	if (bytes < 0)
 		return -1;
 
-	if (bytes < (int) (sizeof(packet.ip) + sizeof(packet.udp)))
-		return -1;
-
-	if (bytes < ntohs(packet.ip.tot_len))
+	tot_len = ntohs(packet.ip.tot_len);
+	if (bytes > tot_len) {
+		/* ignore any extra garbage bytes */
+		bytes = tot_len;
+	} else if (bytes < tot_len) {
 		/* packet is bigger than sizeof(packet), we did partial read */
 		return -1;
+	}
 
-	/* ignore any extra garbage bytes */
-	bytes = ntohs(packet.ip.tot_len);
+	if (bytes < (int) (sizeof(packet.ip) + sizeof(packet.udp)))
+		return -1;
 
 	if (!sanity_check(&packet, bytes))
 		return -1;
@@ -1621,12 +1623,12 @@ static void start_request(GDHCPClient *dhcp_client)
 							NULL);
 }
 
-static uint32_t get_lease(struct dhcp_packet *packet)
+static uint32_t get_lease(struct dhcp_packet *packet, uint16_t packet_len)
 {
 	uint8_t *option;
 	uint32_t lease_seconds;
 
-	option = dhcp_get_option(packet, DHCP_LEASE_TIME);
+	option = dhcp_get_option(packet, packet_len, DHCP_LEASE_TIME);
 	if (!option)
 		return 3600;
 
@@ -2218,7 +2220,8 @@ static void get_dhcpv6_request(GDHCPClient *dhcp_client,
 	}
 }
 
-static void get_request(GDHCPClient *dhcp_client, struct dhcp_packet *packet)
+static void get_request(GDHCPClient *dhcp_client, struct dhcp_packet *packet,
+		uint16_t packet_len)
 {
 	GDHCPOptionType type;
 	GList *list, *value_list;
@@ -2229,7 +2232,7 @@ static void get_request(GDHCPClient *dhcp_client, struct dhcp_packet *packet)
 	for (list = dhcp_client->request_list; list; list = list->next) {
 		code = (uint8_t) GPOINTER_TO_INT(list->data);
 
-		option = dhcp_get_option(packet, code);
+		option = dhcp_get_option(packet, packet_len, code);
 		if (!option) {
 			g_hash_table_remove(dhcp_client->code_value_hash,
 						GINT_TO_POINTER((int) code));
@@ -2261,7 +2264,7 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
 {
 	GDHCPClient *dhcp_client = user_data;
 	struct sockaddr_in dst_addr = { 0 };
-	struct dhcp_packet packet;
+	struct dhcp_packet packet = { 0 };
 	struct dhcpv6_packet *packet6 = NULL;
 	uint8_t *message_type = NULL, *client_id = NULL, *option,
 		*server_id = NULL;
@@ -2289,6 +2292,7 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
 		re = dhcp_recv_l2_packet(&packet,
 					dhcp_client->listener_sockfd,
 					&dst_addr);
+		pkt_len = (uint16_t)(unsigned int)re;
 		xid = packet.xid;
 	} else if (dhcp_client->listen_mode == L3) {
 		if (dhcp_client->type == G_DHCP_IPV6) {
@@ -2353,7 +2357,7 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
 			dhcp_client->status_code = status;
 		}
 	} else {
-		message_type = dhcp_get_option(&packet, DHCP_MESSAGE_TYPE);
+		message_type = dhcp_get_option(&packet, pkt_len, DHCP_MESSAGE_TYPE);
 		if (!message_type)
 			return TRUE;
 	}
@@ -2370,7 +2374,7 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
 		dhcp_client->timeout = 0;
 		dhcp_client->retry_times = 0;
 
-		option = dhcp_get_option(&packet, DHCP_SERVER_ID);
+		option = dhcp_get_option(&packet, pkt_len, DHCP_SERVER_ID);
 		dhcp_client->server_ip = get_be32(option);
 		dhcp_client->requested_ip = ntohl(packet.yiaddr);
 
@@ -2406,9 +2410,9 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
 
 			remove_timeouts(dhcp_client);
 
-			dhcp_client->lease_seconds = get_lease(&packet);
+			dhcp_client->lease_seconds = get_lease(&packet, pkt_len);
 
-			get_request(dhcp_client, &packet);
+			get_request(dhcp_client, &packet, pkt_len);
 
 			switch_listening_mode(dhcp_client, L_NONE);
 
@@ -2416,7 +2420,7 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
 			dhcp_client->assigned_ip = get_ip(packet.yiaddr);
 
 			if (dhcp_client->state == REBOOTING) {
-				option = dhcp_get_option(&packet,
+				option = dhcp_get_option(&packet, pkt_len,
 							DHCP_SERVER_ID);
 				dhcp_client->server_ip = get_be32(option);
 			}

--- a/gdhcp/common.c
+++ b/gdhcp/common.c
@@ -108,18 +108,21 @@ GDHCPOptionType dhcp_get_code_type(uint8_t code)
 	return OPTION_UNKNOWN;
 }
 
-uint8_t *dhcp_get_option(struct dhcp_packet *packet, int code)
+uint8_t *dhcp_get_option(struct dhcp_packet *packet, uint16_t packet_len, int code)
 {
 	int len, rem;
-	uint8_t *optionptr;
+	uint8_t *optionptr, *options_end;
+	size_t options_len;
 	uint8_t overload = 0;
 
 	/* option bytes: [code][len][data1][data2]..[dataLEN] */
 	optionptr = packet->options;
 	rem = sizeof(packet->options);
+	options_len = packet_len - (sizeof(*packet) - sizeof(packet->options));
+	options_end = optionptr + options_len - 1;
 
 	while (1) {
-		if (rem <= 0)
+		if ((rem <= 0) && (optionptr + OPT_CODE > options_end))
 			/* Bad packet, malformed option field */
 			return NULL;
 
@@ -150,14 +153,25 @@ uint8_t *dhcp_get_option(struct dhcp_packet *packet, int code)
 			break;
 		}
 
+		if (optionptr + OPT_LEN > options_end) {
+			/* bad packet, would read length field from OOB */
+			return NULL;
+		}
+
 		len = 2 + optionptr[OPT_LEN];
 
 		rem -= len;
 		if (rem < 0)
 			continue; /* complain and return NULL */
 
-		if (optionptr[OPT_CODE] == code)
-			return optionptr + OPT_DATA;
+		if (optionptr[OPT_CODE] == code) {
+			if (optionptr + len > options_end) {
+				/* bad packet, option length points OOB */
+				return NULL;
+			} else {
+				return optionptr + OPT_DATA;
+			}
+		}
 
 		if (optionptr[OPT_CODE] == DHCP_OPTION_OVERLOAD)
 			overload |= optionptr[OPT_DATA];

--- a/gdhcp/common.h
+++ b/gdhcp/common.h
@@ -178,7 +178,7 @@ struct in6_pktinfo {
 };
 #endif
 
-uint8_t *dhcp_get_option(struct dhcp_packet *packet, int code);
+uint8_t *dhcp_get_option(struct dhcp_packet *packet, uint16_t packet_len, int code);
 uint8_t *dhcpv6_get_option(struct dhcpv6_packet *packet, uint16_t pkt_len,
 			int code, uint16_t *option_len, int *option_count);
 uint8_t *dhcpv6_get_sub_option(unsigned char *option, uint16_t max_len,

--- a/gdhcp/server.c
+++ b/gdhcp/server.c
@@ -413,7 +413,7 @@ error:
 }
 
 
-static uint8_t check_packet_type(struct dhcp_packet *packet)
+static uint8_t check_packet_type(struct dhcp_packet *packet, uint16_t packet_len)
 {
 	uint8_t *type;
 
@@ -423,7 +423,7 @@ static uint8_t check_packet_type(struct dhcp_packet *packet)
 	if (packet->op != BOOTREQUEST)
 		return 0;
 
-	type = dhcp_get_option(packet, DHCP_MESSAGE_TYPE);
+	type = dhcp_get_option(packet, packet_len, DHCP_MESSAGE_TYPE);
 
 	if (!type)
 		return 0;
@@ -651,6 +651,7 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
 	struct dhcp_lease *lease;
 	uint32_t requested_nip = 0;
 	uint8_t type, *server_id_option, *request_ip_option;
+	uint16_t packet_len;
 	int re;
 
 	if (condition & (G_IO_NVAL | G_IO_ERR | G_IO_HUP)) {
@@ -661,12 +662,13 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
 	re = dhcp_recv_l3_packet(&packet, dhcp_server->listener_sockfd);
 	if (re < 0)
 		return TRUE;
+	packet_len = (uint16_t)(unsigned int)re;
 
-	type = check_packet_type(&packet);
+	type = check_packet_type(&packet, packet_len);
 	if (type == 0)
 		return TRUE;
 
-	server_id_option = dhcp_get_option(&packet, DHCP_SERVER_ID);
+	server_id_option = dhcp_get_option(&packet, packet_len, DHCP_SERVER_ID);
 	if (server_id_option) {
 		uint32_t server_nid =
 			get_unaligned((const uint32_t *) server_id_option);
@@ -675,7 +677,7 @@ static gboolean listener_event(GIOChannel *channel, GIOCondition condition,
 			return TRUE;
 	}
 
-	request_ip_option = dhcp_get_option(&packet, DHCP_REQUESTED_IP);
+	request_ip_option = dhcp_get_option(&packet, packet_len, DHCP_REQUESTED_IP);
 	if (request_ip_option)
 		requested_nip = get_be32(request_ip_option);
 

--- a/gweb/gweb.c
+++ b/gweb/gweb.c
@@ -918,7 +918,7 @@ static gboolean received_data(GIOChannel *channel, GIOCondition cond,
 		}
 
 		*pos = '\0';
-		count = strlen((char *) ptr);
+		count = pos - ptr;
 		if (count > 0 && ptr[count - 1] == '\r') {
 			ptr[--count] = '\0';
 			bytes_read--;

--- a/plugins/iwd.c
+++ b/plugins/iwd.c
@@ -55,14 +55,6 @@ static bool agent_registered;
 #define IWD_AGENT_ERROR_INTERFACE	"net.connman.iwd.Agent.Error"
 #define AGENT_PATH			"/net/connman/iwd_agent"
 
-enum iwd_device_state {
-	IWD_DEVICE_STATE_UNKNOWN,
-	IWD_DEVICE_STATE_CONNECTED,
-	IWD_DEVICE_STATE_DISCONNECTED,
-	IWD_DEVICE_STATE_CONNECTING,
-	IWD_DEVICE_STATE_DISCONNECTING,
-};
-
 struct iwd_adapter {
 	GDBusProxy *proxy;
 	char *path;
@@ -77,7 +69,6 @@ struct iwd_device {
 	char *adapter;
 	char *name;
 	char *address;
-	enum iwd_device_state state;
 	bool powered;
 	bool scanning;
 
@@ -95,38 +86,6 @@ struct iwd_network {
 	struct iwd_device *iwdd;
 	struct connman_network *network;
 };
-
-static enum iwd_device_state string2state(const char *str)
-{
-	if (!strcmp(str, "connected"))
-		return IWD_DEVICE_STATE_CONNECTED;
-	else if (!strcmp(str, "disconnected"))
-		return IWD_DEVICE_STATE_DISCONNECTED;
-	else if (!strcmp(str, "connecting"))
-		return IWD_DEVICE_STATE_CONNECTING;
-	else if (!strcmp(str, "disconnecting"))
-		return IWD_DEVICE_STATE_DISCONNECTING;
-
-	return IWD_DEVICE_STATE_UNKNOWN;
-}
-
-static const char *state2string(enum iwd_device_state state)
-{
-	switch (state) {
-	case IWD_DEVICE_STATE_CONNECTED:
-		return "connected";
-	case IWD_DEVICE_STATE_DISCONNECTED:
-		return "disconnected";
-	case IWD_DEVICE_STATE_CONNECTING:
-		return "connecting";
-	case IWD_DEVICE_STATE_DISCONNECTING:
-		return "disconnecting";
-	default:
-		break;
-	}
-
-	return "unknown";
-}
 
 static const char *proxy_get_string(GDBusProxy *proxy, const char *property)
 {
@@ -664,13 +623,6 @@ static void device_property_change(GDBusProxy *proxy, const char *name,
 		iwdd->name = g_strdup(name);
 
 		DBG("%p name %s", path, iwdd->name);
-	} else if (!strcmp(name, "State")) {
-		const char *state;
-
-		dbus_message_iter_get_basic(iter, &state);
-		iwdd->state = string2state(state);
-
-		DBG("%s state %s", path, state2string(iwdd->state));
 	} else if (!strcmp(name, "Powered")) {
 		dbus_bool_t powered;
 
@@ -829,13 +781,11 @@ static void create_device(GDBusProxy *proxy)
 	iwdd->adapter = g_strdup(proxy_get_string(proxy, "Adapter"));
 	iwdd->name = g_strdup(proxy_get_string(proxy, "Name"));
 	iwdd->address = g_strdup(proxy_get_string(proxy, "Address"));
-	iwdd->state = string2state(proxy_get_string(proxy, "State"));
 	iwdd->powered = proxy_get_bool(proxy, "Powered");
 	iwdd->scanning = proxy_get_bool(proxy, "Scanning");
 
-	DBG("adapter %s name %s address %s state %s powered %d scanning %d",
+	DBG("adapter %s name %s address %s powered %d scanning %d",
 		iwdd->adapter, iwdd->name, iwdd->address,
-		state2string(iwdd->state),
 		iwdd->powered, iwdd->scanning);
 
 	g_dbus_proxy_set_property_watch(iwdd->proxy,

--- a/scripts/connman.in
+++ b/scripts/connman.in
@@ -1,8 +1,18 @@
 #!/bin/sh
 
+### BEGIN INIT INFO
+# Provides:       connman
+# Required-Start: $remote_fs $syslog dbus
+# Required-Stop:  $remote_fs $syslog dbus
+# Default-Start:  2 3 4 5
+# Default-Stop:   0 1 6
+# Short-Description: Connection Manager
+### END INIT INFO
+
+
 DAEMON=@sbindir@/connmand
 DESC="Connection Manager"
-
+NAME=connmand
 . /lib/lsb/init-functions
 
 if [ -f @sysconfdir@/default/connman ] ; then
@@ -14,14 +24,21 @@ if [ "CONNMAN_RUNSTATEDIR_RESOLVCONF" != "no" ] ; then
     ln -sf @runstatedir@/connman/resolv.conf /etc/
 fi
 
-set -e
-
 do_start() {
 	start-stop-daemon --start --oknodo --exec $DAEMON -- $DAEMON_OPTS
 }
 
 do_stop() {
 	start-stop-daemon --stop --oknodo --quiet --exec $DAEMON
+}
+
+get_pid() {
+	[ -n "$1" ] || return 0
+	[ -S /run/dbus/system_bus_socket ] || return 0
+
+	dbus-send --system --dest=org.freedesktop.DBus --print-reply \
+		/org/freedesktop/DBus org.freedesktop.DBus.GetConnectionUnixProcessID \
+		string:$1 2>/dev/null | awk '/uint32/ {print $2}'
 }
 
 case "$1" in
@@ -42,8 +59,18 @@ case "$1" in
 	do_start
 	log_end_msg $?
 	;;
+  status)
+	pid=$(get_pid net.connman)
+	if [ -n "$pid" ]; then
+		log_success_msg "$NAME is running"
+		return 0
+	else
+		log_failure_msg "$NAME is not running"
+		return 3 # LSB exit code for "program is not running"
+	fi
+	;;
   *)
-	log_success_msg "Usage: $0 {start|stop|restart|force-reload}" >&2
+	log_success_msg "Usage: $0 {start|stop|status|restart|force-reload}" >&2
 	exit 1
 	;;
 esac

--- a/src/dnsproxy.c
+++ b/src/dnsproxy.c
@@ -2148,6 +2148,7 @@ static char *uncompress(int16_t field_count, char *start, char *end,
 			char **uncompressed_ptr)
 {
 	char *uptr = *uncompressed_ptr; /* position in result buffer */
+	char * const uncomp_end = uncompressed + uncomp_len - 1;
 
 	debug("count %d ptr %p end %p uptr %p", field_count, ptr, end, uptr);
 
@@ -2168,14 +2169,15 @@ static char *uncompress(int16_t field_count, char *start, char *end,
 		 * tmp buffer.
 		 */
 
-		ulen = strlen(name);
-		strncpy(uptr, name, uncomp_len - (uptr - uncompressed));
+		ulen = strlen(name) + 1;
+		if ((uptr + ulen) > uncomp_end)
+			goto out;
+		strncpy(uptr, name, ulen);
 
 		debug("pos %d ulen %d left %d name %s", pos, ulen,
-			(int)(uncomp_len - (uptr - uncompressed)), uptr);
+			(int)(uncomp_end - (uptr + ulen)), uptr);
 
 		uptr += ulen;
-		*uptr++ = '\0';
 
 		ptr += pos;
 
@@ -2183,6 +2185,10 @@ static char *uncompress(int16_t field_count, char *start, char *end,
 		 * We copy also the fixed portion of the result (type, class,
 		 * ttl, address length and the address)
 		 */
+		if ((uptr + NS_RRFIXEDSZ) > uncomp_end) {
+			debug("uncompressed data too large for buffer");
+			goto out;
+		}
 		memcpy(uptr, ptr, NS_RRFIXEDSZ);
 
 		dns_type = uptr[0] << 8 | uptr[1];
@@ -2214,7 +2220,7 @@ static char *uncompress(int16_t field_count, char *start, char *end,
 		} else if (dns_type == ns_t_a || dns_type == ns_t_aaaa) {
 			dlen = uptr[-2] << 8 | uptr[-1];
 
-			if (ptr + dlen > end) {
+			if ((ptr + dlen) > end || (uptr + dlen) > uncomp_end) {
 				debug("data len %d too long", dlen);
 				goto out;
 			}
@@ -2253,6 +2259,10 @@ static char *uncompress(int16_t field_count, char *start, char *end,
 			 * refresh interval, retry interval, expiration
 			 * limit and minimum ttl). They are 20 bytes long.
 			 */
+			if ((uptr + 20) > uncomp_end || (ptr + 20) > end) {
+				debug("soa record too long");
+				goto out;
+			}
 			memcpy(uptr, ptr, 20);
 			uptr += 20;
 			ptr += 20;
@@ -2322,6 +2332,12 @@ static int forward_dns_reply(unsigned char *reply, int reply_len, int protocol,
 
 	if (offset < 0)
 		return offset;
+	if (reply_len < 0)
+		return -EINVAL;
+	if (reply_len < offset + 1)
+		return -EINVAL;
+	if ((size_t)reply_len < sizeof(struct domain_hdr))
+		return -EINVAL;
 
 	hdr = (void *)(reply + offset);
 	dns_id = reply[offset] | reply[offset + 1] << 8;
@@ -2357,23 +2373,31 @@ static int forward_dns_reply(unsigned char *reply, int reply_len, int protocol,
 		 */
 		if (req->append_domain && ntohs(hdr->qdcount) == 1) {
 			uint16_t domain_len = 0;
-			uint16_t header_len;
+			uint16_t header_len, payload_len;
 			uint16_t dns_type, dns_class;
 			uint8_t host_len, dns_type_pos;
 			char uncompressed[NS_MAXDNAME], *uptr;
 			char *ptr, *eom = (char *)reply + reply_len;
+			char *domain;
 
 			/*
 			 * ptr points to the first char of the hostname.
 			 * ->hostname.domain.net
 			 */
 			header_len = offset + sizeof(struct domain_hdr);
+			if (reply_len < header_len)
+				return -EINVAL;
+			payload_len = reply_len - header_len;
+
 			ptr = (char *)reply + header_len;
 
 			host_len = *ptr;
+			domain = ptr + 1 + host_len;
+			if (domain > eom)
+				return -EINVAL;
+
 			if (host_len > 0)
-				domain_len = strnlen(ptr + 1 + host_len,
-						reply_len - header_len);
+				domain_len = strnlen(domain, eom - domain);
 
 			/*
 			 * If the query type is anything other than A or AAAA,
@@ -2382,6 +2406,8 @@ static int forward_dns_reply(unsigned char *reply, int reply_len, int protocol,
 			 */
 			dns_type_pos = host_len + 1 + domain_len + 1;
 
+			if (ptr + (dns_type_pos + 3) > eom)
+				return -EINVAL;
 			dns_type = ptr[dns_type_pos] << 8 |
 							ptr[dns_type_pos + 1];
 			dns_class = ptr[dns_type_pos + 2] << 8 |
@@ -2411,6 +2437,8 @@ static int forward_dns_reply(unsigned char *reply, int reply_len, int protocol,
 				int new_len, fixed_len;
 				char *answers;
 
+				if (len > payload_len)
+					return -EINVAL;
 				/*
 				 * First copy host (without domain name) into
 				 * tmp buffer.
@@ -2425,6 +2453,8 @@ static int forward_dns_reply(unsigned char *reply, int reply_len, int protocol,
 				 * Copy type and class fields of the question.
 				 */
 				ptr += len + domain_len + 1;
+				if (ptr + NS_QFIXEDSZ > eom)
+					return -EINVAL;
 				memcpy(uptr, ptr, NS_QFIXEDSZ);
 
 				/*
@@ -2434,6 +2464,8 @@ static int forward_dns_reply(unsigned char *reply, int reply_len, int protocol,
 				uptr += NS_QFIXEDSZ;
 				answers = uptr;
 				fixed_len = answers - uncompressed;
+				if (ptr + offset > eom)
+					return -EINVAL;
 
 				/*
 				 * We then uncompress the result to buffer
@@ -2612,7 +2644,7 @@ static gboolean udp_server_event(GIOChannel *channel, GIOCondition condition,
 							gpointer user_data)
 {
 	unsigned char buf[4096];
-	int sk, err, len;
+	int sk, len;
 	struct server_data *data = user_data;
 
 	if (condition & (G_IO_NVAL | G_IO_ERR | G_IO_HUP)) {
@@ -2624,12 +2656,8 @@ static gboolean udp_server_event(GIOChannel *channel, GIOCondition condition,
 	sk = g_io_channel_unix_get_fd(channel);
 
 	len = recv(sk, buf, sizeof(buf), 0);
-	if (len < 12)
-		return TRUE;
 
-	err = forward_dns_reply(buf, len, IPPROTO_UDP, data);
-	if (err < 0)
-		return TRUE;
+	forward_dns_reply(buf, len, IPPROTO_UDP, data);
 
 	return TRUE;
 }
@@ -2710,13 +2738,20 @@ hangup:
 			}
 		}
 
+		/*
+		 * Remove the G_IO_OUT flag from the watch, otherwise we end
+		 * up in a busy loop, because the socket is constantly writable.
+		 *
+		 * There seems to be no better way in g_io to do that than
+		 * re-adding the watch.
+		 */
+		g_source_remove(server->watch);
+		server->watch = g_io_add_watch(server->channel,
+			G_IO_IN | G_IO_HUP | G_IO_NVAL | G_IO_ERR,
+			tcp_server_event, server);
+
 		server->connected = true;
 		server_list = g_slist_append(server_list, server);
-
-		if (server->timeout > 0) {
-			g_source_remove(server->timeout);
-			server->timeout = 0;
-		}
 
 		for (list = request_list; list; ) {
 			struct request_data *req = list->data;

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -59,6 +59,7 @@ struct wispr_route {
 };
 
 struct connman_wispr_portal_context {
+	int refcount;
 	struct connman_service *service;
 	enum connman_ipconfig_type type;
 	struct connman_wispr_portal *wispr_portal;
@@ -96,10 +97,13 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data);
 
 static GHashTable *wispr_portal_list = NULL;
 
+#define wispr_portal_context_ref(wp_context) \
+	wispr_portal_context_ref_debug(wp_context, __FILE__, __LINE__, __func__)
+#define wispr_portal_context_unref(wp_context) \
+	wispr_portal_context_unref_debug(wp_context, __FILE__, __LINE__, __func__)
+
 static void connman_wispr_message_init(struct connman_wispr_message *msg)
 {
-	DBG("");
-
 	msg->has_error = false;
 	msg->current_element = NULL;
 
@@ -159,11 +163,6 @@ static void free_wispr_routes(struct connman_wispr_portal_context *wp_context)
 static void free_connman_wispr_portal_context(
 		struct connman_wispr_portal_context *wp_context)
 {
-	DBG("context %p", wp_context);
-
-	if (!wp_context)
-		return;
-
 	if (wp_context->wispr_portal) {
 		if (wp_context->wispr_portal->ipv4_context == wp_context)
 			wp_context->wispr_portal->ipv4_context = NULL;
@@ -200,9 +199,38 @@ static void free_connman_wispr_portal_context(
 	g_free(wp_context);
 }
 
+static struct connman_wispr_portal_context *
+wispr_portal_context_ref_debug(struct connman_wispr_portal_context *wp_context,
+			const char *file, int line, const char *caller)
+{
+	DBG("%p ref %d by %s:%d:%s()", wp_context,
+		wp_context->refcount + 1, file, line, caller);
+
+	__sync_fetch_and_add(&wp_context->refcount, 1);
+
+	return wp_context;
+}
+
+static void wispr_portal_context_unref_debug(
+		struct connman_wispr_portal_context *wp_context,
+		const char *file, int line, const char *caller)
+{
+	if (!wp_context)
+		return;
+
+	DBG("%p ref %d by %s:%d:%s()", wp_context,
+		wp_context->refcount - 1, file, line, caller);
+
+	if (__sync_fetch_and_sub(&wp_context->refcount, 1) != 1)
+		return;
+
+	free_connman_wispr_portal_context(wp_context);
+}
+
 static struct connman_wispr_portal_context *create_wispr_portal_context(void)
 {
-	return g_try_new0(struct connman_wispr_portal_context, 1);
+	return wispr_portal_context_ref(
+		g_new0(struct connman_wispr_portal_context, 1));
 }
 
 static void free_connman_wispr_portal(gpointer data)
@@ -214,8 +242,8 @@ static void free_connman_wispr_portal(gpointer data)
 	if (!wispr_portal)
 		return;
 
-	free_connman_wispr_portal_context(wispr_portal->ipv4_context);
-	free_connman_wispr_portal_context(wispr_portal->ipv6_context);
+	wispr_portal_context_unref(wispr_portal->ipv4_context);
+	wispr_portal_context_unref(wispr_portal->ipv6_context);
 
 	g_free(wispr_portal);
 }
@@ -509,14 +537,17 @@ static void wispr_portal_request_portal(
 {
 	DBG("");
 
+	wispr_portal_context_ref(wp_context);
 	wp_context->request_id = g_web_request_get(wp_context->web,
 					wp_context->status_url,
 					wispr_portal_web_result,
 					wispr_route_request,
 					wp_context);
 
-	if (wp_context->request_id == 0)
+	if (wp_context->request_id == 0) {
 		wispr_portal_error(wp_context);
+		wispr_portal_context_unref(wp_context);
+	}
 }
 
 static bool wispr_input(const guint8 **data, gsize *length,
@@ -562,13 +593,15 @@ static void wispr_portal_browser_reply_cb(struct connman_service *service,
 		return;
 
 	if (!authentication_done) {
-		wispr_portal_error(wp_context);
 		free_wispr_routes(wp_context);
+		wispr_portal_error(wp_context);
+		wispr_portal_context_unref(wp_context);
 		return;
 	}
 
 	/* Restarting the test */
 	__connman_service_wispr_start(service, wp_context->type);
+	wispr_portal_context_unref(wp_context);
 }
 
 static void wispr_portal_request_wispr_login(struct connman_service *service,
@@ -592,7 +625,7 @@ static void wispr_portal_request_wispr_login(struct connman_service *service,
 				return;
 		}
 
-		free_connman_wispr_portal_context(wp_context);
+		wispr_portal_context_unref(wp_context);
 		return;
 	}
 
@@ -644,11 +677,13 @@ static bool wispr_manage_message(GWebResult *result,
 
 		wp_context->wispr_result = CONNMAN_WISPR_RESULT_LOGIN;
 
+		wispr_portal_context_ref(wp_context);
 		if (__connman_agent_request_login_input(wp_context->service,
 					wispr_portal_request_wispr_login,
-					wp_context) != -EINPROGRESS)
+					wp_context) != -EINPROGRESS) {
 			wispr_portal_error(wp_context);
-		else
+			wispr_portal_context_unref(wp_context);
+		} else
 			return true;
 
 		break;
@@ -697,6 +732,7 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
 		if (length > 0) {
 			g_web_parser_feed_data(wp_context->wispr_parser,
 								chunk, length);
+			wispr_portal_context_unref(wp_context);
 			return true;
 		}
 
@@ -714,6 +750,7 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
 
 	switch (status) {
 	case 000:
+		wispr_portal_context_ref(wp_context);
 		__connman_agent_request_browser(wp_context->service,
 				wispr_portal_browser_reply_cb,
 				wp_context->status_url, wp_context);
@@ -725,11 +762,14 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
 		if (g_web_result_get_header(result, "X-ConnMan-Status",
 						&str)) {
 			portal_manage_status(result, wp_context);
+			wispr_portal_context_unref(wp_context);
 			return false;
-		} else
+		} else {
+			wispr_portal_context_ref(wp_context);
 			__connman_agent_request_browser(wp_context->service,
 					wispr_portal_browser_reply_cb,
 					wp_context->redirect_url, wp_context);
+		}
 
 		break;
 	case 302:
@@ -737,6 +777,7 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
 			!g_web_result_get_header(result, "Location",
 							&redirect)) {
 
+			wispr_portal_context_ref(wp_context);
 			__connman_agent_request_browser(wp_context->service,
 					wispr_portal_browser_reply_cb,
 					wp_context->status_url, wp_context);
@@ -747,6 +788,7 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
 
 		wp_context->redirect_url = g_strdup(redirect);
 
+		wispr_portal_context_ref(wp_context);
 		wp_context->request_id = g_web_request_get(wp_context->web,
 				redirect, wispr_portal_web_result,
 				wispr_route_request, wp_context);
@@ -763,6 +805,7 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
 
 		break;
 	case 505:
+		wispr_portal_context_ref(wp_context);
 		__connman_agent_request_browser(wp_context->service,
 				wispr_portal_browser_reply_cb,
 				wp_context->status_url, wp_context);
@@ -775,6 +818,7 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
 	wp_context->request_id = 0;
 done:
 	wp_context->wispr_msg.message_type = -1;
+	wispr_portal_context_unref(wp_context);
 	return false;
 }
 
@@ -809,6 +853,7 @@ static void proxy_callback(const char *proxy, void *user_data)
 					xml_wispr_parser_callback, wp_context);
 
 	wispr_portal_request_portal(wp_context);
+	wispr_portal_context_unref(wp_context);
 }
 
 static gboolean no_proxy_callback(gpointer user_data)
@@ -903,7 +948,7 @@ static int wispr_portal_detect(struct connman_wispr_portal_context *wp_context)
 
 		if (wp_context->token == 0) {
 			err = -EINVAL;
-			free_connman_wispr_portal_context(wp_context);
+			wispr_portal_context_unref(wp_context);
 		}
 	} else if (wp_context->timeout == 0) {
 		wp_context->timeout = g_idle_add(no_proxy_callback, wp_context);
@@ -952,7 +997,7 @@ int __connman_wispr_start(struct connman_service *service,
 
 	/* If there is already an existing context, we wipe it */
 	if (wp_context)
-		free_connman_wispr_portal_context(wp_context);
+		wispr_portal_context_unref(wp_context);
 
 	wp_context = create_wispr_portal_context();
 	if (!wp_context)


### PR DESCRIPTION
This PR takes the source code + patches from the Debian Bullseye package (v.136+ secuirty patches) and applies this ontop of our existing connman v.136 + ultimaker patches.

With this, we are up to teh same functionality + security patch level as Debian Bullseye and we restore specific Ultimaker beahavior in Connman, such as a default config file and a captive portal and wifi tethering without a default password, which is required to run the WiFi Setup wizard.