### PR TITLE
[CES-3236] Fix docker build

### DIFF
--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -18,7 +18,8 @@ BUILD_DIR="${BUILD_DIR_TEMPLATE}"
 update_docker_image()
 {
     echo "Building local Docker build environment."
-    docker build ./docker_env -t "${LOCAL_REGISTRY_IMAGE}"
+    # Always build for linux/arm64 regardless of host architecture
+    docker buildx build --platform linux/arm64 --tag "${LOCAL_REGISTRY_IMAGE}" ./docker_env --load
 }
 
 run_in_docker()

--- a/docker_env/Dockerfile
+++ b/docker_env/Dockerfile
@@ -1,16 +1,19 @@
-FROM arm64v8/debian:buster
+FROM registry.hub.docker.com/library/debian:bookworm-slim
 
 LABEL Maintainer="software-embedded@ultimaker.com" \
-      Comment="Ultimaker buster build environment"
+      Comment="Ultimaker bookworm build environment"
 
+# Install necessary packages for building connman on Bookworm.
+# We're updating the apt cache and installing all build dependencies in one layer
+# to optimize Docker caching.
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
     apt-utils \
     autoconf \
     automake \
     build-essential \
     bzip2 \
-    cmake \ 
+    cmake \
     fakeroot \
     git \
     gnutls-bin \
@@ -19,11 +22,27 @@ RUN apt-get update && \
     libdbus-1-dev \
     libglib2.0-dev \
     libgnutls28-dev \
-    libreadline6-dev \
+    libreadline-dev \
     libtool \
     libxtables-dev \
     pkg-config \
     policykit-1 \
+    # Consider adding other common connman dependencies if needed for your specific build:
+    # libbluetooth-dev # For Bluetooth support
+    # libudev-dev      # For udev integration
+    # libsystemd-dev   # For systemd integration (if using systemd's features)
     && \
     apt-get clean && \
-    rm -rf /var/cache/apt/*
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+
+# Add further steps here if your build process involves
+# cloning specific repos, patching, configuring, compiling, etc.
+# Example:
+# COPY . /connman-source
+# WORKDIR /connman-source
+# RUN ./autogen.sh && \
+#     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var && \
+#     make -j$(nproc) && \
+#     make install DESTDIR=/build_output
+#
+# # You might then want to create a debian package or simply copy the binaries out


### PR DESCRIPTION
With this PR we update the docker to build for Debian Bookwrom (so the correct deps are used) and we also set the architecture explicitly to `arm64` in `build_for_ultimaker.sh` so that it links to the correct shared objects for that architecture (which is what the target system, the printer, is using) instead of linking against the host machines architecture and shared objects.

Testing now shows that using `connmanctl` via the command line no longer complains of a missing shared object, libreadline.so.7, and an `ldd` on the binary shows linkage to libreadline.so.8